### PR TITLE
move hdmi transmission and serdes into HdmiTx

### DIFF
--- a/src/main/scala/HdmiTx.scala
+++ b/src/main/scala/HdmiTx.scala
@@ -1,0 +1,42 @@
+package hdmicore
+
+import chisel3._
+import chisel3.util._
+
+import fpgamacro.gowin.{Oser10Module, TLVDS_OBUF}
+
+class HdmiTx() extends Module {
+  val io = IO(new Bundle {
+    val videoSig = Input(new VideoHdmi())
+    val serClk = Input(Clock())
+    val tmds = Output(new Tmds())
+  })
+
+  /* hdmi transmission */
+  val rgb2tmds = Module(new Rgb2Tmds())
+  rgb2tmds.io.videoSig <> io.videoSig
+
+  /* serdes */
+  // Blue -> data 0
+  val serdesBlue = Module(new Oser10Module())
+  serdesBlue.io.data := rgb2tmds.io.tmds_blue
+  serdesBlue.io.fclk := io.serClk
+
+  // Green -> data 1
+  val serdesGreen = Module(new Oser10Module())
+  serdesGreen.io.data := rgb2tmds.io.tmds_green
+  serdesGreen.io.fclk := io.serClk
+
+  // Red -> data 2
+  val serdesRed = Module(new Oser10Module())
+  serdesRed.io.data := rgb2tmds.io.tmds_red
+  serdesRed.io.fclk := io.serClk
+
+  io.tmds.data := serdesRed.io.q ## serdesGreen.io.q ## serdesBlue.io.q
+
+  // clock
+  val serdesClk = Module(new Oser10Module())
+  serdesClk.io.data := "b1111100000".U(10.W)
+  serdesClk.io.fclk := io.serClk
+  io.tmds.clk := serdesClk.io.q
+}

--- a/src/main/scala/PatternExample.scala
+++ b/src/main/scala/PatternExample.scala
@@ -3,7 +3,7 @@ package hdmicore
 import chisel3._
 import chisel3.util._
 
-import video.{VideoParams, HVSync}
+import video.{VideoParams, HVSync, VideoConsts}
 
 
 sealed trait PatternType
@@ -29,7 +29,8 @@ case object ptVGradient extends PatternType
 case object ptHGradient extends PatternType
 
 
-class PatternExample(pt: PatternType = ptUkraineFlag) extends Module {
+class PatternExample(vp: VideoParams = VideoConsts.m1280x720.params,
+                     pt: PatternType = ptUkraineFlag) extends Module {
   val io = IO(new Bundle {
     val videoSig = Output(new VideoHdmi())
     val I_button = Input(Bool())
@@ -82,13 +83,6 @@ class PatternExample(pt: PatternType = ptUkraineFlag) extends Module {
      case `ptHGradient` => ptIdxHGradient
      case whoa => ptIdxBlackVoid
   }
-
-  val vp = VideoParams(
-      H_DISPLAY = 1280, H_FRONT = 110,
-      H_SYNC = 40, H_BACK = 220,
-      V_SYNC = 5,  V_BACK = 20,
-      V_TOP = 5, V_DISPLAY = 720,
-      V_BOTTOM = 20)
 
   val hv_sync = Module(new HVSync(vp)) // Synchronize VGA module
   val video_de = hv_sync.io.display_on

--- a/src/main/scala/PatternExample.scala
+++ b/src/main/scala/PatternExample.scala
@@ -221,55 +221,55 @@ class PatternExample(pt: PatternType = ptUkraineFlag) extends Module {
     pgreen := Mux(0.U === vpos % 2.U, 0.U, 255.U)
     pblue  := Mux(0.U === vpos % 2.U, 0.U, 255.U)
   } .elsewhen(ptIdx === ptIdxFrenchFlag){
-    val swidth = 1280
+    val swidth = vp.H_DISPLAY
     pred := Mux(hpos < (swidth/3).U, 0.U, 255.U)
     pgreen := Mux((hpos >= (swidth/3).U) && (hpos < (swidth*2/3).U), 255.U, 0.U)
     pblue := Mux(hpos < (swidth*2/3).U, 255.U, 0.U)
   } .elsewhen(ptIdx === ptIdxIrishFlag){
-    val swidth = 1280
+    val swidth = vp.H_DISPLAY
     pred := Mux(hpos < (swidth/3).U, 0.U, 255.U)
     pgreen := Mux(hpos < (swidth*2/3).U, 255.U, 128.U)
     pblue := Mux((hpos >= (swidth/3).U) && (hpos < (swidth*2/3).U), 255.U, 0.U)
   } .elsewhen(ptIdx === ptIdxItalianFlag){
-    val swidth = 1280
+    val swidth = vp.H_DISPLAY
     pred := Mux(hpos < (swidth/3).U, 0.U, 255.U)
     pgreen := Mux(hpos < (swidth*2/3).U, 255.U, 0.U)
     pblue := Mux((hpos >= (swidth/3).U) && (hpos < (swidth*2/3).U), 255.U, 0.U)
   } .elsewhen(ptIdx === ptIdxBelgianFlag){
-    val swidth = 1280
+    val swidth = vp.H_DISPLAY
     pred := Mux(hpos >= (swidth/3).U, 255.U, 0.U)
     pgreen := Mux((hpos >= (swidth/3).U) && (hpos < (swidth*2/3).U), 255.U, 0.U)
     pblue := 0.U
   } .elsewhen(ptIdx === ptIdxDutchFlag){
-    val sheight = 720
+    val sheight = vp.V_DISPLAY
     val prbright = Mux(vpos < (sheight/3).U, 128.U, 255.U)
     val pbbright = Mux(vpos < (sheight*2/3).U, 255.U, 128.U)
     pred := Mux(vpos < (sheight*2/3).U, prbright, 0.U)
     pgreen := Mux((vpos >= (sheight/3).U) && (vpos < (sheight*2/3).U), 255.U, 0.U)
     pblue := Mux(vpos < (sheight/3).U, 0.U, pbbright)
   } .elsewhen(ptIdx === ptIdxLuxembourgishFlag){
-    val sheight = 720
+    val sheight = vp.V_DISPLAY
     pred := Mux(vpos < (sheight*2/3).U, 255.U, 0.U)
     pgreen := Mux((vpos >= (sheight/3).U) && (vpos < (sheight*2/3).U), 255.U, 0.U)
     pblue := Mux(vpos < (sheight/3).U, 0.U, 255.U)
   } .elsewhen(ptIdx === ptIdxGermanFlag){
-    val sheight = 720
+    val sheight = vp.V_DISPLAY
     pred := Mux(vpos >= (sheight/3).U, 255.U, 0.U)
     pgreen := Mux(vpos < (sheight*2/3).U, 0.U, 255.U)
     pblue := 0.U
   } .elsewhen(ptIdx === ptIdxSpanishFlag){
-    val sheight = 720
+    val sheight = vp.V_DISPLAY
     pred := 255.U
     pgreen := Mux((vpos >= (sheight/4).U) && (vpos < (sheight*3/4).U), 255.U, 0.U)
     pblue := 0.U
   } .elsewhen(ptIdx === ptIdxAustrianFlag){
-    val sheight = 720
+    val sheight = vp.V_DISPLAY
     pred := 255.U
     pgreen :=  Mux((vpos >= (sheight/3).U) && (vpos < (sheight*2/3).U), 255.U, 0.U)
     pblue := Mux((vpos >= (sheight/3).U) && (vpos < (sheight*2/3).U), 255.U, 0.U)
   } .elsewhen(ptIdx === ptIdxGreekFlag){
-    val swidth = 1280
-    val sheight = 720
+    val swidth = vp.H_DISPLAY
+    val sheight = vp.V_DISPLAY
     val swstep = swidth*3/80
     val shstep = sheight/9
     val oinv = Mux((hpos <= (swstep*10).U) && (vpos > (shstep*2).U) && (vpos <= (shstep*3).U), 255.U, 0.U)
@@ -279,8 +279,8 @@ class PatternExample(pt: PatternType = ptUkraineFlag) extends Module {
     pgreen := Mux(vpos % (sheight*2/9).U > (sheight/9).U, ninv, pinv)
     pblue := 255.U
   } .elsewhen(ptIdx === ptIdxDanishFlag){
-    val swidth = 1280
-    val sheight = 720
+    val swidth = vp.H_DISPLAY
+    val sheight = vp.V_DISPLAY
     val swstep = swidth*4/37
     val shstep = sheight/7
     val pinv = Mux((hpos > (swstep*3).U) && (hpos <= (swstep*4).U), 255.U, 0.U)
@@ -288,8 +288,8 @@ class PatternExample(pt: PatternType = ptUkraineFlag) extends Module {
     pgreen := Mux((vpos > (shstep*3).U) && (vpos <= (shstep*4).U), 255.U, pinv)
     pblue := Mux((vpos > (shstep*3).U) && (vpos <= (shstep*4).U), 255.U, pinv)
   } .elsewhen(ptIdx === ptIdxSwedishFlag){
-    val swidth = 1280
-    val sheight = 720
+    val swidth = vp.H_DISPLAY
+    val sheight = vp.V_DISPLAY
     val swstep = swidth/16
     val shstep = sheight/5
     val pinv = Mux((hpos > (swstep*5).U) && (hpos <= (swstep*7).U), 255.U, 0.U)
@@ -298,8 +298,8 @@ class PatternExample(pt: PatternType = ptUkraineFlag) extends Module {
     pgreen := Mux((vpos > (shstep*2).U) && (vpos <= (shstep*3).U), 255.U, pinv)
     pblue := Mux((vpos > (shstep*2).U) && (vpos <= (shstep*3).U), 0.U, ninv)
   } .elsewhen(ptIdx === ptIdxFinnishFlag){
-    val swidth = 1280
-    val sheight = 720
+    val swidth = vp.H_DISPLAY
+    val sheight = vp.V_DISPLAY
     val swstep = swidth/18
     val shstep = sheight/11
     val ninv = Mux((hpos > (swstep*5).U) && (hpos <= (swstep*8).U), 0.U, 255.U)
@@ -307,8 +307,8 @@ class PatternExample(pt: PatternType = ptUkraineFlag) extends Module {
     pgreen := Mux((vpos > (shstep*4).U) && (vpos <= (shstep*7).U), 0.U, ninv)
     pblue := 255.U
   } .elsewhen(ptIdx === ptIdxNorwegianFlag){
-    val swidth = 1280
-    val sheight = 720
+    val swidth = vp.H_DISPLAY
+    val sheight = vp.V_DISPLAY
     val swstep = swidth/22
     val shstep = sheight/16
     val minv = Mux((vpos > (shstep*7).U) && (vpos <= (shstep*9).U), 0.U, 255.U)
@@ -324,7 +324,7 @@ class PatternExample(pt: PatternType = ptUkraineFlag) extends Module {
     pblue := Mux((vpos > (shstep*6).U) && (vpos <= (shstep*10).U), pbbright, pinv)
   } .elsewhen(ptIdx === ptIdxUkraineFlag){
    /* blue #00 57 b7, yellow #ff d7 00  */
-    val sheight = 720
+    val sheight = vp.V_DISPLAY
     pred  := Mux(vpos <= (sheight/2).U, "h00".U, "hFF".U)
     pgreen:= Mux(vpos <= (sheight/2).U, "h00".U, "hFF".U)
     pblue := Mux(vpos <= (sheight/2).U, "hFF".U, "h00".U)

--- a/src/main/scala/platforms/tangnano4k.scala
+++ b/src/main/scala/platforms/tangnano4k.scala
@@ -8,7 +8,7 @@ import chisel3.util._
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 
 import fpgamacro.gowin.{CLKDIV, TMDS_PLLVR, TLVDS_OBUF}
-import hdmicore.{PatternExample, TMDSDiff, DiffPair}
+import hdmicore.{PatternExample, TMDSDiff, DiffPair, HdmiTx}
 
 class TangNano4k extends RawModule {
 
@@ -58,18 +58,21 @@ class TangNano4k extends RawModule {
       O_led := (counterReg >= (max_count/2).U)
 
       val patternExample = Module(new PatternExample())
-      patternExample.io.serClk := serial_clk
       patternExample.io.I_button := I_button
+
+      val hdmiTx = Module(new HdmiTx())
+      hdmiTx.io.serClk := serial_clk
+      patternExample.io.videoSig <> hdmiTx.io.videoSig
 
       /* LVDS output */
       val buffDiffBlue = Module(new TLVDS_OBUF())
-      buffDiffBlue.io.I := patternExample.io.tmds.data(0)
+      buffDiffBlue.io.I := hdmiTx.io.tmds.data(0)
       val buffDiffGreen = Module(new TLVDS_OBUF())
-      buffDiffGreen.io.I := patternExample.io.tmds.data(1)
+      buffDiffGreen.io.I := hdmiTx.io.tmds.data(1)
       val buffDiffRed = Module(new TLVDS_OBUF())
-      buffDiffRed.io.I := patternExample.io.tmds.data(2)
+      buffDiffRed.io.I := hdmiTx.io.tmds.data(2)
       val buffDiffClk = Module(new TLVDS_OBUF())
-      buffDiffClk.io.I := patternExample.io.tmds.clk
+      buffDiffClk.io.I := hdmiTx.io.tmds.clk
 
       O_tmds.data(0).p := buffDiffBlue.io.O
       O_tmds.data(0).n := buffDiffBlue.io.OB

--- a/src/main/scala/platforms/tangnano4k.scala
+++ b/src/main/scala/platforms/tangnano4k.scala
@@ -9,8 +9,9 @@ import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 
 import fpgamacro.gowin.{CLKDIV, TMDS_PLLVR, TLVDS_OBUF}
 import hdmicore.{PatternExample, TMDSDiff, DiffPair, HdmiTx}
+import hdmicore.video.{VideoMode, VideoConsts}
 
-class TangNano4k extends RawModule {
+class TangNano4k(vmode: VideoMode = VideoConsts.m1280x720) extends RawModule {
 
     /************/
     /** outputs */
@@ -45,7 +46,7 @@ class TangNano4k extends RawModule {
     clkDiv.io.CALIB := true.B
 
     /* TMDS PLL */
-    val tmdsPllvr = Module(new TMDS_PLLVR())
+    val tmdsPllvr = Module(new TMDS_PLLVR(vmode.pll))
     tmdsPllvr.io.clkin := I_clk
     serial_clk := tmdsPllvr.io.clkout
     pll_lock := tmdsPllvr.io.lock
@@ -57,7 +58,7 @@ class TangNano4k extends RawModule {
       val (counterReg, counterPulse) = Counter(true.B, max_count)
       O_led := (counterReg >= (max_count/2).U)
 
-      val patternExample = Module(new PatternExample())
+      val patternExample = Module(new PatternExample(vmode.params))
       patternExample.io.I_button := I_button
 
       val hdmiTx = Module(new HdmiTx())

--- a/src/main/scala/platforms/ulx3s.scala
+++ b/src/main/scala/platforms/ulx3s.scala
@@ -8,7 +8,7 @@ import chisel3.util._
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 
 import fpgamacro.gowin.{CLKDIV, TMDS_PLLVR, TLVDS_OBUF}
-import hdmicore.{PatternExample, TMDSDiff, DiffPair}
+import hdmicore.{PatternExample, TMDSDiff, DiffPair, HdmiTx}
 
 class Ulx3s extends RawModule {
 
@@ -58,18 +58,21 @@ class Ulx3s extends RawModule {
       O_led := (counterReg >= (max_count/2).U)
 
       val patternExample = Module(new PatternExample())
-      patternExample.io.serClk := serial_clk
       patternExample.io.I_button := I_button
+
+      val hdmiTx = Module(new HdmiTx())
+      hdmiTx.io.serClk := serial_clk
+      patternExample.io.videoSig <> hdmiTx.io.videoSig
 
       /* LVDS output */
       val buffDiffBlue = Module(new TLVDS_OBUF())
-      buffDiffBlue.io.I := patternExample.io.tmds.data(0)
+      buffDiffBlue.io.I := hdmiTx.io.tmds.data(0)
       val buffDiffGreen = Module(new TLVDS_OBUF())
-      buffDiffGreen.io.I := patternExample.io.tmds.data(1)
+      buffDiffGreen.io.I := hdmiTx.io.tmds.data(1)
       val buffDiffRed = Module(new TLVDS_OBUF())
-      buffDiffRed.io.I := patternExample.io.tmds.data(2)
+      buffDiffRed.io.I := hdmiTx.io.tmds.data(2)
       val buffDiffClk = Module(new TLVDS_OBUF())
-      buffDiffClk.io.I := patternExample.io.tmds.clk
+      buffDiffClk.io.I := hdmiTx.io.tmds.clk
 
       O_tmds.data(0).p := buffDiffBlue.io.O
       O_tmds.data(0).n := buffDiffBlue.io.OB

--- a/src/main/scala/video/VideoConsts.scala
+++ b/src/main/scala/video/VideoConsts.scala
@@ -14,6 +14,7 @@ package object VideoConsts {
   val p40000khz  = PLLParams(IDIV_SEL = 4, FBDIV_SEL = 36, ODIV_SEL = 4, DYN_SDIV_SEL = 16)
   val p51400khz  = PLLParams(IDIV_SEL = 1, FBDIV_SEL = 18, ODIV_SEL = 4, DYN_SDIV_SEL = 20)
   val p65000khz  = PLLParams(IDIV_SEL = 0, FBDIV_SEL = 11, ODIV_SEL = 2, DYN_SDIV_SEL = 26)
+  val p71100khz  = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 52, ODIV_SEL = 2, DYN_SDIV_SEL = 30)
   val p74250khz  = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL = 2, DYN_SDIV_SEL = 30)
   val p85500khz  = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 62, ODIV_SEL = 2, DYN_SDIV_SEL = 34)
   val p106500khz = PLLParams(IDIV_SEL = 2, FBDIV_SEL = 58, ODIV_SEL = 2, DYN_SDIV_SEL = 42)
@@ -103,6 +104,18 @@ package object VideoConsts {
       V_BOTTOM = 20
     ),
     pll = p74250khz
+  )
+
+  // D: 71.10 MHz, H: 49.380 kHz, V: 60.00 Hz
+  val m1280x800 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 1280, H_FRONT = 48,
+      H_SYNC = 32, H_BACK = 80,
+      V_SYNC = 6,  V_BACK = 14,
+      V_TOP = 3, V_DISPLAY = 800,
+      V_BOTTOM = 14
+    ),
+    pll = p71100khz
   )
 
   // D: 85.50 MHz, H: 47.700 kHz, V: 60.00 Hz

--- a/src/main/scala/video/VideoConsts.scala
+++ b/src/main/scala/video/VideoConsts.scala
@@ -15,6 +15,8 @@ package object VideoConsts {
   val p51400khz  = PLLParams(IDIV_SEL = 1, FBDIV_SEL = 18, ODIV_SEL = 4, DYN_SDIV_SEL = 20)
   val p65000khz  = PLLParams(IDIV_SEL = 0, FBDIV_SEL = 11, ODIV_SEL = 2, DYN_SDIV_SEL = 26)
   val p74250khz  = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL = 2, DYN_SDIV_SEL = 30)
+  val p85500khz  = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 62, ODIV_SEL = 2, DYN_SDIV_SEL = 34)
+  val p106500khz = PLLParams(IDIV_SEL = 2, FBDIV_SEL = 58, ODIV_SEL = 2, DYN_SDIV_SEL = 42)
   val p108000khz = PLLParams(IDIV_SEL = 0, FBDIV_SEL = 19, ODIV_SEL = 2, DYN_SDIV_SEL = 44)
 
   // to be checked
@@ -101,6 +103,42 @@ package object VideoConsts {
       V_BOTTOM = 20
     ),
     pll = p74250khz
+  )
+
+  // D: 85.50 MHz, H: 47.700 kHz, V: 60.00 Hz
+  val m1360x768 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 1360, H_FRONT = 64,
+      H_SYNC = 112, H_BACK = 256,
+      V_SYNC = 6,  V_BACK = 18,
+      V_TOP = 3, V_DISPLAY = 768,
+      V_BOTTOM = 18
+    ),
+    pll = p85500khz
+  )
+
+  // D: 85.50 MHz, H: 47.880 kHz, V: 60.00 Hz
+  val m1366x768 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 1366, H_FRONT = 70,
+      H_SYNC = 143, H_BACK = 213,
+      V_SYNC = 3,  V_BACK = 24,
+      V_TOP = 3, V_DISPLAY = 768,
+      V_BOTTOM = 24
+    ),
+    pll = p85500khz
+  )
+
+  // D: 106.50 MHz, H: 56.040 kHz, V: 60.00 Hz
+  val m1440x900 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 1440, H_FRONT = 80,
+      H_SYNC = 152, H_BACK = 232,
+      V_SYNC = 6,  V_BACK = 25,
+      V_TOP = 3, V_DISPLAY = 900,
+      V_BOTTOM = 25
+    ),
+    pll = p106500khz
   )
 
   // D: 108.00 MHz, H: 63.981 kHz, V: 60.02 Hz

--- a/src/main/scala/video/VideoConsts.scala
+++ b/src/main/scala/video/VideoConsts.scala
@@ -1,0 +1,129 @@
+package hdmicore.video
+
+import chisel3._
+import fpgamacro.gowin.PLLParams
+
+case class VideoMode(
+  val params: VideoParams,
+  val pll: PLLParams
+)
+
+package object VideoConsts {
+  val p25920khz  = PLLParams(IDIV_SEL = 4, FBDIV_SEL = 23, ODIV_SEL = 8, DYN_SDIV_SEL =  4) // DYN_SDIV_SEL = 10
+  val p27000khz  = PLLParams(IDIV_SEL = 0, FBDIV_SEL =  4, ODIV_SEL = 8, DYN_SDIV_SEL = 10)
+  val p40000khz  = PLLParams(IDIV_SEL = 4, FBDIV_SEL = 36, ODIV_SEL = 4, DYN_SDIV_SEL = 16)
+  val p51400khz  = PLLParams(IDIV_SEL = 1, FBDIV_SEL = 18, ODIV_SEL = 4, DYN_SDIV_SEL = 20)
+  val p65000khz  = PLLParams(IDIV_SEL = 0, FBDIV_SEL = 11, ODIV_SEL = 2, DYN_SDIV_SEL = 26)
+  val p74250khz  = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL = 2, DYN_SDIV_SEL = 30)
+  val p108000khz = PLLParams(IDIV_SEL = 0, FBDIV_SEL = 19, ODIV_SEL = 2, DYN_SDIV_SEL = 44)
+
+  // to be checked
+  // D: 27.00 MHz, H: 31.469 kHz, V: 59.94 Hz
+  val m720x480 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 720, H_FRONT = 16,
+      H_SYNC = 62, H_BACK = 60,
+      V_SYNC = 6,  V_BACK = 30,
+      V_TOP = 9, V_DISPLAY = 480,
+      V_BOTTOM = 30
+    ),
+    pll = p27000khz
+  )
+
+  // D: 27.00 MHz, H: 31.250 kHz, V: 50.00 Hz
+  val m720x576 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 720, H_FRONT = 12,
+      H_SYNC = 64, H_BACK = 68,
+      V_SYNC = 5,  V_BACK = 39,
+      V_TOP = 5, V_DISPLAY = 576,
+      V_BOTTOM = 39
+    ),
+    pll = p27000khz
+  )
+
+  // D: 25,92 MHz, only for supported displays
+  val m800x480 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 800, H_FRONT = 210,
+      H_SYNC = 1, H_BACK = 182,
+      V_SYNC = 5, V_BACK = 0,
+      V_TOP = 45, V_DISPLAY = 480,
+      V_BOTTOM = 0
+    ),
+    pll = p25920khz
+  )
+
+  // to be checked
+  // D: 40.00 MHz, H: 37.879 kHz, V: 60.32 Hz
+  val m800x600 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 800, H_FRONT = 40,
+      H_SYNC = 128, H_BACK = 88,
+      V_SYNC = 4,  V_BACK = 23,
+      V_TOP = 1, V_DISPLAY = 600,
+      V_BOTTOM = 23
+    ),
+    pll = p40000khz
+  )
+
+  // D: 51.40 MHz, H: 38.280 kHz, V: 60.00 Hz
+  val m1024x600 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 1024, H_FRONT = 24,
+      H_SYNC = 136, H_BACK = 160,
+      V_SYNC = 6,  V_BACK = 29,
+      V_TOP = 3, V_DISPLAY = 600,
+      V_BOTTOM = 29
+    ),
+    pll = p51400khz
+  )
+
+  // D: 65.00 MHz, H: 48.363 kHz, V: 60.00 Hz
+  val m1024x768 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 1024, H_FRONT = 24,
+      H_SYNC = 136, H_BACK = 160,
+      V_SYNC = 6,  V_BACK = 29,
+      V_TOP = 3, V_DISPLAY = 768,
+      V_BOTTOM = 29
+    ),
+    pll = p65000khz
+  )
+
+  // D: 74.25 MHz, H: 45.000 kHz, V: 60.00 Hz
+  val m1280x720 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 1280, H_FRONT = 110,
+      H_SYNC = 40, H_BACK = 220,
+      V_SYNC = 5,  V_BACK = 20,
+      V_TOP = 5, V_DISPLAY = 720,
+      V_BOTTOM = 20
+    ),
+    pll = p74250khz
+  )
+
+  // D: 108.00 MHz, H: 63.981 kHz, V: 60.02 Hz
+  val m1280x1024 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 1280, H_FRONT = 48,
+      H_SYNC = 112, H_BACK = 248,
+      V_SYNC = 3,  V_BACK = 38,
+      V_TOP = 1, V_DISPLAY = 1024,
+      V_BOTTOM = 38
+    ),
+    pll = p108000khz
+  )
+
+  // D: 108.00 MHz, H: 60.000 kHz, V: 60.00 Hz
+  val m1600x900 = VideoMode(
+    params = VideoParams(
+      H_DISPLAY = 1600, H_FRONT = 24,
+      H_SYNC = 80, H_BACK = 96,
+      V_SYNC = 3,  V_BACK = 96,
+      V_TOP = 1, V_DISPLAY = 900,
+      V_BOTTOM = 96
+    ),
+    pll = p108000khz
+  )
+}


### PR DESCRIPTION
Just an idea about keeping code like PatternExample hardware independent by moving the output handling into a new module named HdmiTx.
When using VideoHdmi as io videoSig the interconnect is a one-liner.